### PR TITLE
Don't use invalid phone IDs as index.

### DIFF
--- a/src/java/com/android/internal/telephony/dataconnection/DctController.java
+++ b/src/java/com/android/internal/telephony/dataconnection/DctController.java
@@ -363,14 +363,15 @@ public class DctController extends Handler {
                              mSubController.getCurrentDds());
                     mPhones[prefPhoneId].unregisterForAllDataDisconnected(this);
                 }
-                Message allowedDataDone = Message.obtain(this,
-                        EVENT_SET_DATA_ALLOW_DONE, s);
-                Phone phone = mPhones[phoneId].getActivePhone();
+                if (phoneId >= 0) {
+                    Message allowedDataDone = Message.obtain(this,
+                            EVENT_SET_DATA_ALLOW_DONE, s);
+                    Phone phone = mPhones[phoneId].getActivePhone();
 
-                informDefaultDdsToPropServ(phoneId);
-                DcTrackerBase dcTracker =((PhoneBase)phone).mDcTracker;
-                dcTracker.setDataAllowed(true, allowedDataDone);
-
+                    informDefaultDdsToPropServ(phoneId);
+                    DcTrackerBase dcTracker =((PhoneBase)phone).mDcTracker;
+                    dcTracker.setDataAllowed(true, allowedDataDone);
+                }
                break;
             }
 


### PR DESCRIPTION
phoneId can be -1 via this path, triggered via SimBootReceiver:
java.lang.Throwable
     at com.android.internal.telephony.dataconnection.DctController$SwitchInfo.<init>(DctController.java:743)
     at com.android.internal.telephony.dataconnection.DctController.setDefaultDataSubId(DctController.java:781)
     at com.android.internal.telephony.SubscriptionController.setDefaultDataSubId(SubscriptionController.java:1443)
     at com.android.internal.telephony.SubscriptionController.clearDefaultsForInactiveSubIds(SubscriptionController.java:1533)
     at com.android.internal.telephony.ISub$Stub.onTransact(ISub.java:307)
     at android.os.Binder.execTransact(Binder.java:446

Change-Id: Idf050fe5fff9b24cdbf890d0abc12d52fba21b3f
